### PR TITLE
fix: corrigir ambiguidade no seletor de teste de caracteres especiais

### DIFF
--- a/tests/components/ResultsModal_AccessPage.comprehensive.test.tsx
+++ b/tests/components/ResultsModal_AccessPage.comprehensive.test.tsx
@@ -265,7 +265,10 @@ describe('ResultsModal - Comprehensive Quality Tests', () => {
       ];
 
       render(<ResultsModal isOpen={true} results={specialResults} onClose={mockClose} />);
-      expect(screen.getByText(/Result/)).toBeInTheDocument();
+      // Validar que os 3 items com caracteres especiais foram renderizados corretamente
+      expect(screen.getByText('Result & Co.')).toBeInTheDocument();
+      expect(screen.getByText('Result "Quoted"')).toBeInTheDocument();
+      expect(screen.getByText("Result's Name")).toBeInTheDocument();
     });
 
     it('should handle very long descriptions', () => {


### PR DESCRIPTION
## 🔧 Correção: Ambiguidade em Seletor de Teste

### Motivo da Correção
Teste `"should handle special characters in result names"` em `ResultsModal_AccessPage.comprehensive.test.tsx` estava falhando durante execução.

### Descrição do Problema

**Erro Original**:
```
Found multiple elements with the text: /Result/
```

**Causa Raiz**: 
O teste usava um seletor ambíguo: `screen.getByText(/Result/)`

React Testing Library encontrava **3 elementos simultâneos** que correspondiam a este padrão:
1. "Result & Co."
2. "Result "Quoted""
3. "Result's Name"

Quando múltiplos elementos combinam com um seletor, `getByText()` lança erro (foi corrigido seguindo as melhores práticas de Testing Library).

### Solução Aplicada

**ANTES** (linha 265):
```tsx
expect(screen.getByText(/Result/)).toBeInTheDocument();
```

**DEPOIS** (linhas 265-269):
```tsx
expect(screen.getByText('Result & Co.')).toBeInTheDocument();
expect(screen.getByText('Result "Quoted"')).toBeInTheDocument();
expect(screen.getByText("Result's Name")).toBeInTheDocument();
```

### Benefícios da Correção

✅ **Mais específico**: Cada assertion valida um item exato  
✅ **Mais legível**: Não há ambiguidade no que o teste valida  
✅ **Mais robusto**: Não depende de padrões regex frágeis  
✅ **Segue padrões**: Alinhado com melhores práticas de React Testing Library  

### Validação Realizada

- ✅ Teste target: **40/40 tests passing** (100%)
- ✅ Regressões: **Zero** (nenhuma falha em outros testes)
- ✅ Lint: **ESLint pre-commit hooks passed**
- ✅ Cobertura: Mantida (nenhuma linha removida, apenas refatorada)

### Arquivos Modificados

- `tests/components/ResultsModal_AccessPage.comprehensive.test.tsx` (1 alteração, linhas 260-280)

### Checklist

- [x] Problema foi corrigido (não é uma gambiarra)
- [x] Solução valida o código real, não o teste
- [x] Todos os 40 testes do arquivo passam
- [x] Sem regressões em outros testes
- [x] Código segue padrões do projeto
- [x] Documento Mestre foi atualizado (#update_log)
- [x] Commit seguiu estrutura HOTFIX PROTOCOL 1.0
- [x] ESLint passou em pré-commit hooks

### Referências

- **Commit**: `0ba275b`
- **Protocolo**: HOTFIX_TEST_VALIDATION_1.0
- **Branch**: `fix/test-ambiguity-resultsmodal`
- **Status do Sistema**: 🟢 GREEN STATE (todos os testes validados)